### PR TITLE
update level input values to include maximum and minimum values

### DIFF
--- a/5e-slot-calculator.html
+++ b/5e-slot-calculator.html
@@ -37,16 +37,16 @@
                     <th>Wizard</th>
                 </tr>
                 <tr>
-                    <td><input class="level-input half-up" type="number" value="0"></td>
-                    <td><input class="level-input full" type="number" value="0"></td>
-                    <td><input class="level-input full" type="number" value="0"></td>
-                    <td><input class="level-input full" type="number" value="0"></td>
-                    <td><input class="level-input third" type="number" value="0"></td>
-                    <td><input class="level-input half" type="number" value="0"></td>
-                    <td><input class="level-input half" type="number" value="0"></td>
-                    <td><input class="level-input third" type="number" value="0"></td>
-                    <td><input class="level-input full" type="number" value="0"></td>
-                    <td><input class="level-input full" type="number" value="0"></td>
+                    <td><input class="level-input half-up" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input full" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input full" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input full" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input third" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input half" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input half" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input third" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input full" type="number" value="0" min="0" max="20"></td>
+                    <td><input class="level-input full" type="number" value="0" min="0" max="20"></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Currently, the page allows negative values, and levels past 20.  This
results in an issue where, should a user input an invalid value into
one of the level selectors, the value for all slots will be '-'.
This PR resolves this issue.

I noticed this issue, and it has also been requested to be fixed by
/u/Maple__Syrup__ on the /r/dndnext post you made.
